### PR TITLE
Remove build-essential cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,14 +8,11 @@ version          '12.0.0'
 issues_url 'https://github.com/evertrue/zookeeper-cookbook/issues'
 source_url 'https://github.com/evertrue/zookeeper-cookbook/'
 
-supports         'ubuntu', '>= 16.04'
 supports         'centos', '~> 7.0'
-supports         'oracle', '~> 7.0'
 supports         'redhat', '~> 7.0'
 
 chef_version     '>= 12.10'
 
-depends          'build-essential', '>= 5.0'
 depends          'java', '>= 1.39'
 depends          'runit', '>= 1.7'
 depends          'magic', '>= 1.1'

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -39,10 +39,8 @@ action :install do
     Chef::Log.info "Assuming you've provided your own Java"
   end
 
-  # build-essential is required to build the zookeeper gem
-  build_essential 'install compilation tools' do
-    compile_time true
-  end
+  # some build tools are required to build the zookeeper gem
+  package %w{ autoconf bison flex gcc gcc-c++ gettext make m4 ncurses-devel patch }
 
   chef_gem 'zookeeper' do
     compile_time false


### PR DESCRIPTION
Since chef 14, the cookbook is merged in chef, but does not allow an
easy way to enable a specific repo when installing needed packages. This
was making installation of `kernel-devel` fail as Criteo dedicated
kernel was in a separate and disabled by default repo.

Simple solution is to remove build-essential cookbook from zookeeper
cookbook, and manually install needed dependencies.