### PR TITLE
Dynamic reconfiguration

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -64,10 +64,11 @@ module Zk
     end
 
     def dynamic_config!(c)
+      require 'mixlib/shellout'
       # FIXME(t.lange): zk gem will hopefully export the reconfig command one day
       authstr = ''
       authstr = "addauth #{auth_scheme} #{auth_cert}\n" unless auth_cert.nil?
-      `echo -e "#{authstr}reconfig -members #{c}" | /opt/zookeeper/bin/zkCli.sh`
+      Mixlib::ShellOut.new("echo -e \"#{authstr}reconfig -members #{c}\" | /opt/zookeeper/bin/zkCli.sh").run_command.error!
     end
 
     def compile_acls

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -49,6 +49,27 @@ module Zk
       end
     end
 
+    def has_dynamic_config?(nodes, conf_file)
+      return false if nodes.size <= 1
+
+      File.readlines(conf_file).any? do |line|
+        line =~ /dynamicConfigFile/
+      end
+    end
+
+    def dynamic_config_version(conf_file)
+      File.readlines(conf_file).select do |line|
+        line =~ /dynamicConfigFile/
+      end[0].split('=')[1].strip
+    end
+
+    def dynamic_config!(c)
+      # FIXME(t.lange): zk gem will hopefully export the reconfig command one day
+      authstr = ''
+      authstr = "addauth #{auth_scheme} #{auth_cert}\n" unless auth_cert.nil?
+      `echo -e "#{authstr}reconfig -members #{c}" | /opt/zookeeper/bin/zkCli.sh`
+    end
+
     def compile_acls
       require 'zookeeper'
 

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -49,6 +49,9 @@ action :install do
     compile_time false
   end
 
+  chef_gem 'mixlib-shellout' do
+  end
+
   group new_resource.username
 
   user new_resource.username do

--- a/resources/dynconfig.rb
+++ b/resources/dynconfig.rb
@@ -1,0 +1,37 @@
+#
+# Cookbook:: zookeeper
+# Resource:: dynconfig
+#
+# Copyright:: 2014, Simple Finance Technology Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+property :nodes,            Hash, default: {}
+property :static_conf,      String, default: ""
+property :auth_cert,   [String, nil], desired_state: false
+property :auth_scheme, default: 'digest', desired_state: false
+property :connect_str, String, required: true, desired_state: false
+
+include Zk::Gem
+
+action :create do
+  return unless has_dynamic_config?(new_resource.nodes, new_resource.static_conf)
+
+  conf = new_resource.nodes.map do |k,v|
+    "#{k}=#{v}" 
+  end.join(';2181,') + ';2181'
+  dynamic_config!(conf)
+end
+
+action :delete do
+end


### PR DESCRIPTION
Note: this won't be merge in the target branch; using this PR just to gather feedbacks :)

The goal of this is to split configuration of Zookeeper in two:
* one for the static config (with regular options)
* one for the node config (part of static config in old zk versions, or par of dynamic one in recent config).

For now it's using the zkCli tool to do a full update of members as the zk gem does not expose the `reconfig` command.
The change will apply the change each time for now, and will do a setup of complete set of members to prevent the need of computing deleted and/or added nodes.

Also we are protected from race conditions using our choregraphie.