### PR TITLE
♾️ Fix periodic rewrite of static conf by chef

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://filer-rubygems.prod.crto.in/'
+gem 'chef', '14.7.17' # Currently supported Chef version in the CI.
+gem 'chef-dk'
+gem 'chefspec', '>= 7.4.0'
+gem 'berkshelf'

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ gem 'chef', '14.7.17' # Currently supported Chef version in the CI.
 gem 'chef-dk'
 gem 'chefspec', '>= 7.4.0'
 gem 'berkshelf'
+gem 'rubocop'

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -57,19 +57,8 @@ module Zk
     end
 
     def apply!(source)
-      update = source.reject { |k, _| IMMUTABLE_FIELDS.include?(k) }
-      transform_values!.with_index do |v, i|
-        k = keys[i]
-        if IMMUTABLE_FIELDS.include?(k)
-          v
-        elsif !update.key?(k)
-          nil
-        else
-          update.delete(k)
-        end
-      end
-      compact!
-      merge!(update)
+      reject! { |k, _| !source.keys.include?(k) && !IMMUTABLE_FIELDS.include?(k) }
+      merge!(source.reject { |k, _| IMMUTABLE_FIELDS.include?(k) })
       self
     end
 

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -63,7 +63,8 @@ module Zk
       ZookeeperConfig.new(config: config)
     end
 
-    def apply!(update)
+    def apply!(source)
+      update = source.dup
       immutable_fields = %w[dynamicConfigFile]
       immutable_fields.each { |k| update.removekey!(k) }
       @config.map! do |k|
@@ -95,8 +96,17 @@ module Zk
       @config.select { |k| k.keys.first == key }.first.values.first
     end
 
+    def index(key)
+      val = @config.find { |k| k.keys.first == key }
+      @config.index(val)
+    end
+
     def to_s
       @config.map { |k| "#{k.keys.first}=#{k.values.first}" }.join("\n")
+    end
+
+    def dup
+      ZookeeperConfig.new(config: config.dup)
     end
   end
 

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -41,9 +41,16 @@ module Zk
   end
 
   class ZookeeperConfig < Hash
+    # Note: Hash are ordered by insert order in Ruby
+    # so we use this to read file in order and generate same
+    # output order. merge will update existing fields and
+    # create new fields at the end of the key list.
     IMMUTABLE_FIELDS = %w(dynamicConfigFile).freeze
 
     def self.from_h(input)
+      # Order is irrelevant here, as it's used for
+      # chef attribute 'config', and this hash
+      # is user defined so it can be anything anyway
       ZookeeperConfig.new.merge(input)
     end
 

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -63,9 +63,9 @@ module Zk
       ZookeeperConfig.new(config: config)
     end
 
-    def apply(update)
+    def apply!(update)
       immutable_fields = %w[dynamicConfigFile]
-      immutable_fields.each { |k| update.removekey(k) }
+      immutable_fields.each { |k| update.removekey!(k) }
       @config.map! do |k|
         key = k.keys.first
         if immutable_fields.include?(key)
@@ -78,9 +78,9 @@ module Zk
           update.removekey!(key)
           { key => val }
         end
-      end.reject!(:nil?)
+      end.compact!
       update.config.each { |k| @config.append(k) }
-      to_s
+      self
     end
 
     def haskey?(key)

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,6 +14,6 @@ supports         'oracle', '>= 7.0'
 supports         'redhat', '>= 7.0'
 
 chef_version     '>= 14.0'
-depends          'java'
+depends          'java', '< 8.0.0'
 depends          'magic', '>= 1.1'
 depends          'ark', '~> 5.0'

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -51,11 +51,11 @@ action :create do
     content lazy do
       new_conf = Zk::ZookeeperConfig.from_h(conf)
       old_conf = if File.exist?(static_conf)
-                   Zk::ZookeeperConfig.from_text(File.read(static_conf)
+                   Zk::ZookeeperConfig.from_text(File.read(static_conf))
                  else
                    Zk::ZookeeperConfig.new()
                  end
-      old_conf.apply(new_conf)
+      old_conf.apply!(new_conf).to_s
     end
   end
 

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -40,12 +40,12 @@ action :create do
     recursive true
   end
   static_conf = "#{new_resource.conf_dir}/#{new_resource.conf_file}"
-  conf = new_resource.config
+  conf = new_resource.config.dup
   unless has_dynamic_config?(new_resource.nodes, static_conf)
     conf.merge!(new_resource.nodes)
   end
 
-  file "#{new_resource.conf_dir}/#{new_resource.conf_file}" do
+  file static_conf do
     owner   new_resource.user
     group   new_resource.user
     content lazy do

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -39,24 +39,24 @@ action :create do
     group     new_resource.user
     recursive true
   end
-  static_conf = "#{new_resource.conf_dir}/#{new_resource.conf_file}"
-  conf = new_resource.config.dup
-  unless has_dynamic_config?(new_resource.nodes, static_conf)
-    conf.merge!(new_resource.nodes)
-  end
 
-  file static_conf do
+  file "#{new_resource.conf_dir}/#{new_resource.conf_file}" do
     owner   new_resource.user
     group   new_resource.user
-    content lazy do
+    content (lazy do
+      static_conf = "#{new_resource.conf_dir}/#{new_resource.conf_file}"
+      conf = new_resource.config.dup
+      unless has_dynamic_config?(new_resource.nodes, static_conf)
+        conf.merge!(new_resource.nodes)
+      end
       new_conf = Zk::ZookeeperConfig.from_h(conf)
-      old_conf = if File.exist?(static_conf)
-                   Zk::ZookeeperConfig.from_text(File.read(static_conf))
+      old_conf = if ::File.exist?(static_conf)
+                   Zk::ZookeeperConfig.from_text(::File.read(static_conf))
                  else
                    Zk::ZookeeperConfig.new()
                  end
       old_conf.apply!(new_conf).to_s
-    end
+    end)
   end
 
   # Ensure that, even if an attribute is passed in, we can

--- a/resources/dynconfig.rb
+++ b/resources/dynconfig.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 
 property :nodes,            Hash, default: {}
-property :static_conf,      String, default: ""
+property :static_conf,      String, default: ''
 property :auth_cert,   [String, nil], desired_state: false
 property :auth_scheme, default: 'digest', desired_state: false
 property :connect_str, String, required: true, desired_state: false

--- a/resources/dynconfig.rb
+++ b/resources/dynconfig.rb
@@ -27,8 +27,8 @@ include Zk::Gem
 action :create do
   return unless has_dynamic_config?(new_resource.nodes, new_resource.static_conf)
 
-  conf = new_resource.nodes.map do |k,v|
-    "#{k}=#{v}" 
+  conf = new_resource.nodes.map do |k, v|
+    "#{k}=#{v}"
   end.join(';2181,') + ';2181'
   dynamic_config!(conf)
 end

--- a/spec/unit/resources/zookeeper_spec.rb
+++ b/spec/unit/resources/zookeeper_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require_relative '../../../libraries/default.rb'
 
 describe 'zookeeper' do
   step_into :zookeeper
@@ -14,5 +15,82 @@ describe 'zookeeper' do
     end
 
     it { is_expected.to install_ark('zookeeper') }
+  end
+end
+
+RSpec.describe Zk::ZookeeperConfig do
+  describe '#from_h' do
+    let(:hash_config) do
+      { 'itemA' => 'valueA', 'itemB' => 'valueB' }
+    end
+    it 'generates a valid object' do
+      subject = Zk::ZookeeperConfig.from_h(hash_config)
+    end
+  end
+
+  describe '#from_file' do
+    let(:file_config) do
+      "itemA=valueA\nitemB=valueB"
+    end
+    it 'generates a valid object' do
+      subject = Zk::ZookeeperConfig.from_text(file_config)
+      expect(subject).not_to eq nil
+    end
+    it 'exports exactly like the input' do
+      subject = Zk::ZookeeperConfig.from_text(file_config)
+      expect(subject.to_s).to eq(file_config)
+    end
+  end
+
+  describe '#apply' do
+    let(:existing_hash) do
+      { 'keyA' => 'valueA', 'keyB' => 'valueB', 'keyC' => 'valueC' }
+    end
+
+    let(:existing_config) do
+      Zk::ZookeeperConfig.from_h(existing_hash)
+    end
+
+    let(:update_hash) do
+      { 'keyC' => 'valueC', 'keyD' => 'valueD', 'keyA' => 'valueE'}
+    end
+
+    let(:update_config) do
+      Zk::ZookeeperConfig.from_h(update_hash)
+    end
+
+    let(:subject) do
+      existing_config.apply!(update_config)
+    end
+
+    it 'updates existing fields' do
+      expect(subject.value('keyA')).to eq 'valueE'
+    end
+
+    it 'removes removed fields' do
+      expect(subject.haskey?('keyB')).to be_falsy
+    end
+
+    it 'adds added fields' do
+      expect(subject.value('keyD')).to eq 'valueD'
+    end
+
+    it 'keeps order of updated fields' do
+      new_entry = subject.config.find{ |k| k.keys.first == 'keyA'}
+      old_entry = existing_config.config.find{ |k| k.keys.first == 'keyA'}
+
+      expect(subject.config.index(new_entry)).to eq existing_config.config.index(old_entry)
+    end
+
+    context 'with immutable_fields in conf' do
+      before do
+        existing_hash.merge!({ 'dynamicConfigFile' => 'good' })
+        update_hash.merge!({ 'dynamicConfigFile' => 'bad' })
+      end
+      it 'does not update them' do
+        expect(subject.value('dynamicConfigFile')).to eq 'good'
+      end
+    end
+
   end
 end

--- a/spec/unit/resources/zookeeper_spec.rb
+++ b/spec/unit/resources/zookeeper_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Zk::ZookeeperConfig do
     end
     it 'generates a valid object' do
       subject = Zk::ZookeeperConfig.from_h(hash_config)
+      expect(subject).not_to eq nil
     end
   end
 
@@ -52,7 +53,7 @@ RSpec.describe Zk::ZookeeperConfig do
     end
 
     let(:update_hash) do
-      { 'keyC' => 'valueC', 'keyD' => 'valueD', 'keyA' => 'valueE'}
+      { 'keyC' => 'valueC', 'keyD' => 'valueD', 'keyA' => 'valueE' }
     end
 
     let(:update_config) do
@@ -76,10 +77,19 @@ RSpec.describe Zk::ZookeeperConfig do
     end
 
     it 'keeps order of updated fields' do
-      new_entry = subject.config.find{ |k| k.keys.first == 'keyA'}
-      old_entry = existing_config.config.find{ |k| k.keys.first == 'keyA'}
+      expect(subject.index('keyA')).to eq existing_config.index('keyA')
+    end
 
-      expect(subject.config.index(new_entry)).to eq existing_config.config.index(old_entry)
+    it 'does not alter update object' do
+      subject
+      expect(update_config.to_s).to eq Zk::ZookeeperConfig.from_h(update_hash).to_s
+    end
+
+    context 'there is no change' do
+      let(:update_hash) { existing_hash }
+      it 'is idempotent' do
+        expect(subject.to_s).to eq existing_config.to_s
+      end
     end
 
     context 'with immutable_fields in conf' do

--- a/spec/unit/resources/zookeeper_spec.rb
+++ b/spec/unit/resources/zookeeper_spec.rb
@@ -65,15 +65,15 @@ RSpec.describe Zk::ZookeeperConfig do
     end
 
     it 'updates existing fields' do
-      expect(subject.value('keyA')).to eq 'valueE'
+      expect(subject.fetch('keyA')).to eq 'valueE'
     end
 
     it 'removes removed fields' do
-      expect(subject.haskey?('keyB')).to be_falsy
+      expect(subject.key?('keyB')).to be_falsy
     end
 
     it 'adds added fields' do
-      expect(subject.value('keyD')).to eq 'valueD'
+      expect(subject.fetch('keyD')).to eq 'valueD'
     end
 
     it 'keeps order of updated fields' do
@@ -92,15 +92,32 @@ RSpec.describe Zk::ZookeeperConfig do
       end
     end
 
-    context 'with immutable_fields in conf' do
+    context 'with immutable_fields in previous and new conf' do
       before do
         existing_hash.merge!({ 'dynamicConfigFile' => 'good' })
         update_hash.merge!({ 'dynamicConfigFile' => 'bad' })
       end
       it 'does not update them' do
-        expect(subject.value('dynamicConfigFile')).to eq 'good'
+        expect(existing_config.fetch('dynamicConfigFile')).to eq 'good'
+        expect(update_config.fetch('dynamicConfigFile')).to eq 'bad'
+        expect(subject.fetch('dynamicConfigFile')).to eq 'good'
       end
     end
-
+    context 'with immutable_fields in previous conf only' do
+      before do
+        existing_hash.merge!({ 'dynamicConfigFile' => 'good' })
+      end
+      it 'is preserved' do
+        expect(subject.fetch('dynamicConfigFile')).to eq 'good'
+      end
+    end
+    context 'with immutable_fields in new conf only' do
+      before do
+        update_hash.merge!({ 'dynamicConfigFile' => 'good' })
+      end
+      it 'is not created' do
+        expect(subject.key?('dynamicConfigFile')).to be_falsy
+      end
+    end
   end
 end


### PR DESCRIPTION
This is a temporary branch to make a proper review, I'll push directly on the branch when reviewed.
---

This is because when dynamicReconfig is enabled, Zookeeper rewrites its
static conf with new dynamicConfigFile file, but it also reorders the
other keys. So we now keep order of keys, and append the new ones at the
end (they will be reorder when reconfig will be called once).

JIRA: MESOS-4478