### PR TITLE
🔧 2nd quickfix for the dynamic config

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -61,7 +61,7 @@ module Zk
 
         # NOTE: Client port is remaining group
         fqdn, port1, port2, = val.match(/^(.*):([0-9]+):([0-9]+):/).captures
-        h.merge!({ key => "#{fqdn}:#{port1}:#{port2}" })
+        h.merge!({ key => "#{fqdn}:#{port1}:#{port2}:participant;0.0.0.0:2181" })
       end
       h
     end


### PR DESCRIPTION
The real cause (why client host/port is absent of the initial configuration?) is still unknown, but we now know enough about the symptoms to produce a working fix.
The previous fix addressed the fact that the regex wasn't matching anymore the input when client port wasn't provided, but hid the absence of client port configuration. And since 604eebc1192b8d208776f42ce3fecfcbd1c8f7e3 we remove clientPort from the static config part, so not providing the clientPort in the dynamic configuration Zookeeper has no way to know of which port to listen to.
The present patch ensures (with ugly hardcoded values) that we always provide a clientPort for every node in the cluster. The patch will be followed eventually by a proper, more reliable fix.

See: https://zookeeper.apache.org/doc/r3.5.3-beta/zookeeperReconfig.html#sc_reconfig_clientport