### PR TITLE
Do not leak credentials when authentication scheme configuration fails

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -129,6 +129,9 @@ module Zk
       # use class variable otherwise new connection is created for each resource
       @@zk ||= ::Zookeeper.new(connect_str).tap do |zk|
         zk.add_auth scheme: auth_scheme, cert: auth_cert unless auth_cert.nil?
+      rescue StandardError => e
+        # do not leak credentials
+        raise "Failed to configure Zookeeper auth scheme `#{auth_scheme}`: #{e.class.name}"
       end
     end
 


### PR DESCRIPTION
When Zookeeper is unreachable, authentication scheme configuration fails with the following error message, leaking credentials:

> Zookeeper::Exceptions::ContinuationTimeoutError
> response for meth: :add_auth, args: [0, "digest", "<user>:<password>"], not received within 30 seconds

We don't want that, this commit fixes the issue.