### PR TITLE
Fix dynconf chicken and egg

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -124,6 +124,27 @@ module Zk
   end
 
   module Gem
+    def zookeeper_running_and_healthy?
+      require 'socket'
+      require 'timeout'
+
+      # Extract host and port from connect_str (e.g. "localhost:2181")
+      host, port = connect_str.split(':')
+      port = port.to_i
+
+      begin
+        Timeout.timeout(3) do
+          socket = TCPSocket.new(host, port)
+          socket.puts('ruok')
+          response = socket.gets&.strip
+          socket.close
+          response == 'imok'
+        end
+      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Timeout::Error, SocketError
+        false
+      end
+    end
+
     def zk
       require 'zookeeper'
       # use class variable otherwise new connection is created for each resource

--- a/resources/dynconfig.rb
+++ b/resources/dynconfig.rb
@@ -36,7 +36,10 @@ action :create do
   # dynamic config file may be missing on disk. Either way, we cannot
   # apply reconfig via the API. zookeeper_config and the service
   # restart will converge on the next chef run once ZK is up.
-  return unless zookeeper_running_and_healthy?
+  unless zookeeper_running_and_healthy?
+    Chef::Log.warn 'zookeeper not running or not healthy, skipping dynamic reconfiguration'
+    return
+  end
 
   original = Zk::ZookeeperDynamicConfig.from_api(dynamic_config)
   target = Zk::ZookeeperDynamicConfig.from_h(new_resource.nodes)

--- a/resources/dynconfig.rb
+++ b/resources/dynconfig.rb
@@ -31,6 +31,13 @@ action :create do
 
   return unless has_dynamic_config?(new_resource.nodes, new_resource.static_conf)
 
+  # If Zookeeper is not running and healthy, skip dynamic reconfig.
+  # The service may not have started yet (e.g. after a reboot) or the
+  # dynamic config file may be missing on disk. Either way, we cannot
+  # apply reconfig via the API. zookeeper_config and the service
+  # restart will converge on the next chef run once ZK is up.
+  return unless zookeeper_running_and_healthy?
+
   original = Zk::ZookeeperDynamicConfig.from_api(dynamic_config)
   target = Zk::ZookeeperDynamicConfig.from_h(new_resource.nodes)
 


### PR DESCRIPTION
Add a `zookeeper_running_and_healthy?` helper (TCP `ruok` probe) and a guard clause in `zookeeper_dynconfig` that skips the resource when Zookeeper isn't healthy. This fixes a chicken-and-egg issue: `zookeeper_dynconfig` needs ZK running to apply reconfig via the API, but the recipe aborts before `zookeeper_config` and the service start can converge, leaving ZK down indefinitely across successive runs. With the guard, the recipe completes — ZK gets its config and starts — and the dynamic reconfig applies on the next run.
